### PR TITLE
Fix incorrect brace and parameter expansion

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -8,8 +8,6 @@ do
   sleep 30
   result=$(curl -X GET --header "Accept: */*" "https://endtest.io/api.php?action=getResults&appId=${1}&appCode=${2}&hash=${hash}&format=json")
 
-  echo $result
-
   if [ "$result" == "Test is still running." ]
   then
     status=$result

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,9 @@ while [ $loop -le $4 ]
 do
   sleep 30
   result=$(curl -X GET --header "Accept: */*" "https://endtest.io/api.php?action=getResults&appId=${1}&appCode=${2}&hash=${hash}&format=json")
+
+  echo $result
+
   if [ "$result" == "Test is still running." ]
   then
     status=$result

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 hash=$(curl -X GET --header "Accept: */*" "${3}")
-for run in {1.."${4}"}
+loop=1
+
+while [ $loop -le $4 ]
 do
   sleep 30
   result=$(curl -X GET --header "Accept: */*" "https://endtest.io/api.php?action=getResults&appId=${1}&appCode=${2}&hash=${hash}&format=json")


### PR DESCRIPTION
Tried to use this and discovered the loop doesn't work due to improperly used brace expansion.

Brace expansion is done before parameter expansion so the for loop ignores the `number_of_loops` parameter and never shows the output.

Fixed by converting to while loop.