### PR TITLE
Support multiple Endtest test executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,103 @@
-![endtest logo](https://app.endtest.io/images/endtest_logo_small.svg)
+![Endtest logo](https://app.endtest.io/images/endtest_logo_small.svg)
 
-# Endtest GitHub Run Tests Deployment Action
+# Endtest GitHub Run Tests Action
 
-This GitHub Action creates an [Endtest](https://endtest.io) deployment event, triggering any functional
-tests associated with that deployment and waiting for their results.
+This GitHub Action triggers one or more Endtest test executions, waits for all of them to finish, and exposes their results as workflow outputs.
 
-### Example workflow:
+It supports both API response shapes:
 
-```
+* A single execution hash, usually returned when the request uses `suite`.
+* Multiple comma-separated execution hashes, usually returned when the request uses `label` and matches multiple test suites.
+
+## Example workflow
+
+```yaml
 on: [push]
 
-name: endtest
+name: Endtest
 
 jobs:
   test:
-    name: Endtest Functional Test
+    name: Endtest functional tests
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - name: Functional test deployment
-        id: endtest_functional_tests
-        uses: endtest-technologies/github-run-tests-action@v1.8
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests with the Critical label
+        id: endtest
+        uses: endtest-technologies/github-run-tests-action@v1.9
         with:
-          app_id: <your-endtest-app-id>
-          app_code: <your-endtest-app-code>
-          api_request: <your-endtest-api-request-for-starting-a-test-execution>
-          number_of_loops: <the-number-of-times-the-API-request-for-fetching-the-results-will-be-sent-once-every-30-seconds>
+          app_id: ${{ secrets.ENDTEST_APP_ID }}
+          app_code: ${{ secrets.ENDTEST_APP_CODE }}
+          api_request: >-
+            https://app.endtest.io/api.php?action=runWeb&appId=${{ secrets.ENDTEST_APP_ID }}&appCode=${{ secrets.ENDTEST_APP_CODE }}&label=Critical&platform=windows&os=windows11&browser=chrome&browserVersion=latest&resolution=1280x1024&geolocation=sanfrancisco&cases=all&notes=
+          number_of_loops: 60
+          results_format: json-light
 
-      - name: Use the outputs from test execution in a different step
+      - name: Show the execution summary
+        env:
+          EXECUTION_COUNT: ${{ steps.endtest.outputs.execution_count }}
+          TEST_CASES: ${{ steps.endtest.outputs.test_cases }}
+          PASSED: ${{ steps.endtest.outputs.passed }}
+          FAILED: ${{ steps.endtest.outputs.failed }}
+          ERRORS: ${{ steps.endtest.outputs.errors }}
+          TEST_EXECUTIONS: ${{ steps.endtest.outputs.test_executions }}
         run: |
-          echo ${{ steps.endtest_functional_tests.outputs.test_suite_name }}
-          echo ${{ steps.endtest_functional_tests.outputs.configuration }}
-          echo ${{ steps.endtest_functional_tests.outputs.test_cases }}
-          echo ${{ steps.endtest_functional_tests.outputs.passed }}
-          echo ${{ steps.endtest_functional_tests.outputs.failed }}
-          echo ${{ steps.endtest_functional_tests.outputs.errors }}
-          echo ${{ steps.endtest_functional_tests.outputs.start_time }}
-          echo ${{ steps.endtest_functional_tests.outputs.end_time }}
-          echo ${{ steps.endtest_functional_tests.outputs.detailed_logs }}
-          echo ${{ steps.endtest_functional_tests.outputs.screenshots_and_video }}
-          echo ${{ steps.endtest_functional_tests.outputs.hash }}
-          echo ${{ steps.endtest_functional_tests.outputs.results }}
-
+          echo "Executions: $EXECUTION_COUNT"
+          echo "Test cases: $TEST_CASES"
+          echo "Passed assertions: $PASSED"
+          echo "Failed assertions: $FAILED"
+          echo "Errors: $ERRORS"
+          echo "$TEST_EXECUTIONS" | jq
 ```
 
-### Environment variables
+## Inputs
 
-- `GITHUB_TOKEN` {string} (optional) - The Github token for your repository. If
-  provided, the Endtest action will associate a pull request with the deployment if
-  the commit being built is associated with any pull requests. This token is
-  automatically available as a secret in your repo but must be passed in
-  explicitly in order for the action to be able to access it.
+* `app_id` {string}, required: The App ID for your Endtest account, available on the [Endtest Settings page](https://app.endtest.io/settings).
+* `app_code` {string}, required: The App Code for your Endtest account, available on the [Endtest Settings page](https://app.endtest.io/settings).
+* `api_request` {string}, required: The complete Endtest API request that starts the test execution or executions.
+* `number_of_loops` {integer}, required: The maximum number of result checks. The action waits 30 seconds before each check.
+* `results_format` {string}, optional: `json` for detailed logs and media URLs, or `json-light` for a smaller summary response. The default is `json`.
 
-### Inputs
+## Multiple execution behavior
 
-- `app_id` {string} - The App ID for your Endtest account ([available here](https://app.endtest.io/settings)).
-- `app_code` {string} - The App Code for your Endtest account ([available here](https://app.endtest.io/settings)).
-- `api_request` {string} - The Endtest API request.
-- `number_of_loops` {int32} - The number of times the API request for fetching the results will be sent once every 30 seconds.
+When Endtest returns multiple hashes, the action sends all hashes in one `getResults` request and waits until the API returns a result for every hash.
 
+The existing outputs remain convenient for single executions and behave as follows for multiple executions:
 
-### Outputs:
+* `test_suite_name` and `configuration` become JSON arrays.
+* `test_cases`, `passed`, `failed`, and `errors` are totals across all executions.
+* `start_time` is the earliest start time and `end_time` is the latest end time.
+* `detailed_logs` and `screenshots_and_video` are flattened JSON arrays.
+* `results` becomes a JSON array of individual Endtest Results page URLs.
 
-* `test_suite_name` {string} - The name of the test suite.
-* `configuration` {string} - The configuration of the machine or mobile device on which the test was executed.
-* `test_cases` {int32} - The number of test cases.
-* `passed` {int32} - The number of assertions that have passed.
-* `failed` {int32} - The number of assertions that have failed.
-* `errors` {int32} - The number of errors that have been encountered.
-* `start_time` {timestamp} - The timestamp for the start of the test execution.
-* `end_time` {timestamp} - The timestamp for the end of the test execution.
-* `detailed_logs` {string} - The detailed logs for the test execution.
-* `screenshots_and_video` {string} - The URLs for the screenshots and the video recording of the test execution.
-* `hash` {string} - The unique hash for the test execution.
-* `results` {string} - The link to the Results page for the test execution.
+Use `test_executions` when you need the complete per-execution data without aggregation.
+
+## Outputs
+
+* `test_suite_name` {string}: One test suite name, or a JSON array of names.
+* `configuration` {string}: One configuration, or a JSON array of configurations.
+* `test_cases` {integer}: Total test cases across all executions.
+* `passed` {integer}: Total passed assertions across all executions.
+* `failed` {integer}: Total failed assertions across all executions.
+* `errors` {integer}: Total errors across all executions.
+* `start_time` {timestamp}: Earliest execution start time.
+* `end_time` {timestamp}: Latest execution end time.
+* `detailed_logs` {JSON string}: Flattened detailed logs. This is an empty array with `json-light`.
+* `screenshots_and_video` {JSON string}: Flattened screenshot, log, and video URLs. This is an empty array with `json-light`.
+* `hash` {string}: The original hash response, including comma-separated hashes.
+* `results` {string}: One Results page URL, or a JSON array of URLs.
+* `execution_count` {integer}: Number of completed executions.
+* `hashes` {JSON string}: Array of execution hashes.
+* `result_urls` {JSON string}: Array of Results page URLs.
+* `test_executions` {JSON string}: Complete API response normalized to an array.
+
+## Error handling
+
+The action fails with a clear message when:
+
+* The trigger request does not return a valid hash or comma-separated hash list.
+* Endtest returns `Erred.`.
+* The results response is not valid JSON.
+* Not all execution results are available before `number_of_loops` is exhausted.

--- a/action.yml
+++ b/action.yml
@@ -1,67 +1,100 @@
 name: "Run Endtest functional tests"
-description: "Register a deployment event with Endtest and run the functional tests"
+description: "Trigger one or more Endtest test executions and wait for their results"
 branding:
   icon: play-circle
   color: white
+
 inputs:
   app_id:
-    description: 'The Endtest App ID for your account. You can get it from the https://app.endtest.io/settings page.'
+    description: "The Endtest App ID for your account. You can get it from https://app.endtest.io/settings."
     required: true
   app_code:
-    description: 'The Endtest App Code for your account. You can get it from the https://app.endtest.io/settings page.'
+    description: "The Endtest App Code for your account. You can get it from https://app.endtest.io/settings."
     required: true
   api_request:
-    description: 'The Endtest API request for starting the test execution.'
+    description: "The Endtest API request that starts one or more test executions. The response may contain one hash or multiple comma-separated hashes."
     required: true
   number_of_loops:
-    description: 'The number of times the API request for fetching the results will be sent once every 30 seconds.'
+    description: "The maximum number of result checks. Checks run once every 30 seconds."
     required: true
+  results_format:
+    description: "The Endtest results format: json or json-light."
+    required: false
+    default: "json"
 
 outputs:
   test_suite_name:
-    description: "The name of the test suite"
+    description: "One test suite name, or a JSON array of names when multiple executions were triggered"
     value: ${{ steps.endtest_functional_tests.outputs.test_suite_name }}
   configuration:
-    description: "The configuration of the machine or mobile device on which the test was executed"
+    description: "One execution configuration, or a JSON array of configurations when multiple executions were triggered"
     value: ${{ steps.endtest_functional_tests.outputs.configuration }}
   test_cases:
-    description: "The number of test cases"
+    description: "Total number of test cases across all executions"
     value: ${{ steps.endtest_functional_tests.outputs.test_cases }}
   passed:
-    description: "The number of assertions that have passed"
+    description: "Total number of passed assertions across all executions"
     value: ${{ steps.endtest_functional_tests.outputs.passed }}
   failed:
-    description: "The number of assertions that have failed"
+    description: "Total number of failed assertions across all executions"
     value: ${{ steps.endtest_functional_tests.outputs.failed }}
   errors:
-    description: "The number of errors that have been encountered"
+    description: "Total number of errors across all executions"
     value: ${{ steps.endtest_functional_tests.outputs.errors }}
   start_time:
-    description: "The timestamp for the start of the test execution."
+    description: "The earliest execution start timestamp"
     value: ${{ steps.endtest_functional_tests.outputs.start_time }}
   end_time:
-    description: "The timestamp for the end of the test execution."
+    description: "The latest execution end timestamp"
     value: ${{ steps.endtest_functional_tests.outputs.end_time }}
   detailed_logs:
-    description: "The detailed logs for the test execution"
+    description: "A flattened JSON array containing detailed logs from all executions. Empty when results_format is json-light."
     value: ${{ steps.endtest_functional_tests.outputs.detailed_logs }}
   screenshots_and_video:
-    description: "The URLs for the screenshts and video recordings of the test execution"
+    description: "A flattened JSON array containing screenshot, log, and video URLs from all executions. Empty when results_format is json-light."
     value: ${{ steps.endtest_functional_tests.outputs.screenshots_and_video }}
   hash:
-   description: "The unique hash for the test execution"
-   value: ${{ steps.endtest_functional_tests.outputs.hash }}
+    description: "The hash returned by Endtest, including comma-separated hashes for multiple executions"
+    value: ${{ steps.endtest_functional_tests.outputs.hash }}
   results:
-   description: "The link to the Results page for the test execution"
-   value: ${{ steps.endtest_functional_tests.outputs.results }}
+    description: "One Endtest Results page URL, or a JSON array of URLs when multiple executions were triggered"
+    value: ${{ steps.endtest_functional_tests.outputs.results }}
+  execution_count:
+    description: "The number of completed test executions"
+    value: ${{ steps.endtest_functional_tests.outputs.execution_count }}
+  hashes:
+    description: "A JSON array containing every execution hash"
+    value: ${{ steps.endtest_functional_tests.outputs.hashes }}
+  result_urls:
+    description: "A JSON array containing an Endtest Results page URL for every execution"
+    value: ${{ steps.endtest_functional_tests.outputs.result_urls }}
+  test_executions:
+    description: "The complete Endtest API response normalized to a JSON array"
+    value: ${{ steps.endtest_functional_tests.outputs.test_executions }}
 
 runs:
   using: "composite"
   steps:
-    - run: sudo apt-get install jq
+    - name: Ensure jq is available
+      run: |
+        if ! command -v jq >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y jq
+        fi
       shell: bash
-    - run: sudo chmod +x ${{ github.action_path }}/test.sh
-      shell: bash
+
     - id: endtest_functional_tests
-      run: ${{ github.action_path }}/test.sh ${{ inputs.app_id }} ${{ inputs.app_code }} "${{ inputs.api_request }}" ${{ inputs.number_of_loops }}
+      env:
+        ENDTEST_APP_ID: ${{ inputs.app_id }}
+        ENDTEST_APP_CODE: ${{ inputs.app_code }}
+        ENDTEST_API_REQUEST: ${{ inputs.api_request }}
+        ENDTEST_NUMBER_OF_LOOPS: ${{ inputs.number_of_loops }}
+        ENDTEST_RESULTS_FORMAT: ${{ inputs.results_format }}
+      run: |
+        bash "${{ github.action_path }}/test.sh" \
+          "$ENDTEST_APP_ID" \
+          "$ENDTEST_APP_CODE" \
+          "$ENDTEST_API_REQUEST" \
+          "$ENDTEST_NUMBER_OF_LOOPS" \
+          "$ENDTEST_RESULTS_FORMAT"
       shell: bash

--- a/test.sh
+++ b/test.sh
@@ -1,70 +1,173 @@
-#!/bin/bash
-set -e
-hash=$(curl -X GET --header "Accept: */*" "${3}")
-loop=1
+#!/usr/bin/env bash
+set -euo pipefail
 
-while [ $loop -le $4 ]
-do
-  sleep 30
-  result=$(curl -X GET --header "Accept: */*" "https://app.endtest.io/api.php?action=getResults&appId=${1}&appCode=${2}&hash=${hash}&format=json")
+APP_ID="${1:-}"
+APP_CODE="${2:-}"
+API_REQUEST="${3:-}"
+NUMBER_OF_LOOPS="${4:-}"
+RESULTS_FORMAT="${5:-json}"
+POLL_INTERVAL_SECONDS="${ENDTEST_POLL_INTERVAL_SECONDS:-30}"
 
-  if [ "$result" == "Test is still running." ]
-  then
-    status=$result
-    # Don't print anything
-  elif [ "$result" == "Processing video recording." ]
-  then
-    status=$result
-    # Don't print anything
-  elif [ "$result" == "Stopping." ]
-  then
-    status=$result
-  elif [ "$result" == "Erred." ]
-  then
-    status=$result
-    echo $status
-  elif [ "$result" == "" ]
-  then
-    status=$result
-    # Don't print anything
+if [[ -z "$APP_ID" || -z "$APP_CODE" || -z "$API_REQUEST" || -z "$NUMBER_OF_LOOPS" ]]; then
+  echo "Missing required arguments: app_id, app_code, api_request, and number_of_loops." >&2
+  exit 1
+fi
+
+if ! [[ "$NUMBER_OF_LOOPS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "number_of_loops must be a positive integer." >&2
+  exit 1
+fi
+
+if [[ "$RESULTS_FORMAT" != "json" && "$RESULTS_FORMAT" != "json-light" ]]; then
+  echo "results_format must be either json or json-light." >&2
+  exit 1
+fi
+
+if ! [[ "$POLL_INTERVAL_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "ENDTEST_POLL_INTERVAL_SECONDS must be a non-negative integer." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but was not found on the runner." >&2
+  exit 1
+fi
+
+write_output() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    local delimiter="ENDTEST_${name}_$$_${RANDOM}"
+    {
+      printf '%s<<%s\n' "$name" "$delimiter"
+      printf '%s\n' "$value"
+      printf '%s\n' "$delimiter"
+    } >> "$GITHUB_OUTPUT"
   else
-     testsuitename=$( echo $result | jq '.test_suite_name' )
-     configuration=$( echo $result | jq '.configuration' )
-     testcases=$( echo $result | jq '.test_cases' )
-     passed=$( echo $result | jq '.passed' )
-     failed=$( echo $result | jq '.failed' )
-     errors=$( echo $result | jq '.errors' )
-     detailedlogs=$( echo $result | jq '.detailed_logs' )
-     screenshotsandvideo=$( echo $result | jq '.screenshots_and_video' )
-     starttime=$( echo $result | jq '.start_time' )
-     endtime=$( echo $result | jq '.end_time' )
-
-     results=https://app.endtest.io/results?hash="$hash"
-
-     echo Test Suite Name: $testsuitename
-     echo Configuration: $configuration
-     echo Test Cases: $testcases
-     echo Passed: $passed
-     echo Failed: $failed
-     echo Errors: $errors
-     echo Start Time: $starttime
-     echo End Time: $endtime
-     echo Hash: $hash
-     echo Results: $results
-
-     echo ::set-output name=test_suite_name::$( echo $testsuitename )
-     echo ::set-output name=configuration::$( echo $configuration )
-     echo ::set-output name=test_cases::$( echo $testcases )
-     echo ::set-output name=passed::$( echo $passed )
-     echo ::set-output name=failed::$( echo $failed )
-     echo ::set-output name=errors::$( echo $errors )
-     echo ::set-output name=start_time::$( echo $starttime )
-     echo ::set-output name=end_time::$( echo $endtime )
-     echo ::set-output name=detailed_logs::$( echo $detailedlogs )
-     echo ::set-output name=screenshots_and_video::$( echo $screenshotsandvideo )
-     echo ::set-output name=hash::$( echo $hash )
-     echo ::set-output name=results::$( echo $results )
-     exit 0
+    printf '%s=%s\n' "$name" "$value"
   fi
+}
+
+trigger_response=$(curl --silent --show-error --fail --request GET --header "Accept: */*" "$API_REQUEST")
+hash=$(printf '%s' "$trigger_response" | tr -d '\r\n' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+if [[ -z "$hash" ]]; then
+  echo "Endtest did not return an execution hash." >&2
+  exit 1
+fi
+
+if ! [[ "$hash" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]]; then
+  echo "Endtest returned an unexpected execution hash response: $hash" >&2
+  exit 1
+fi
+
+hashes_json=$(printf '%s' "$hash" | jq -R -c 'split(",")')
+hash_count=$(printf '%s' "$hashes_json" | jq 'length')
+
+echo "Triggered $hash_count Endtest test execution(s)."
+
+last_status=""
+normalized_results=""
+
+for ((loop = 1; loop <= NUMBER_OF_LOOPS; loop++)); do
+  sleep "$POLL_INTERVAL_SECONDS"
+
+  result=$(curl --silent --show-error --fail --get "https://app.endtest.io/api.php" \
+    --data-urlencode "action=getResults" \
+    --data-urlencode "appId=$APP_ID" \
+    --data-urlencode "appCode=$APP_CODE" \
+    --data-urlencode "hash=$hash" \
+    --data-urlencode "format=$RESULTS_FORMAT")
+
+  case "$result" in
+    "Test is still running."|"Processing video recording."|"Stopping."|"")
+      last_status="$result"
+      continue
+      ;;
+    "Erred.")
+      echo "Endtest reported that the test execution erred." >&2
+      exit 1
+      ;;
+  esac
+
+  if ! normalized_results=$(printf '%s' "$result" | jq -c '
+    if type == "array" then .
+    elif type == "object" then [.]
+    else error("Expected an Endtest result object or array")
+    end
+  ' 2>/dev/null); then
+    echo "Endtest returned an unexpected results response: $result" >&2
+    exit 1
+  fi
+
+  execution_count=$(printf '%s' "$normalized_results" | jq 'length')
+
+  if [[ "$execution_count" -lt "$hash_count" ]]; then
+    last_status="Received $execution_count of $hash_count execution results."
+    continue
+  fi
+
+  test_suite_name=$(printf '%s' "$normalized_results" | jq -r '
+    if length == 1 then .[0].test_suite_name // ""
+    else map(.test_suite_name // "") | @json
+    end
+  ')
+  configuration=$(printf '%s' "$normalized_results" | jq -r '
+    if length == 1 then .[0].configuration // ""
+    else map(.configuration // "") | @json
+    end
+  ')
+  test_cases=$(printf '%s' "$normalized_results" | jq '[.[] | (.test_cases // 0 | tonumber? // 0)] | add // 0')
+  passed=$(printf '%s' "$normalized_results" | jq '[.[] | (.passed // 0 | tonumber? // 0)] | add // 0')
+  failed=$(printf '%s' "$normalized_results" | jq '[.[] | (.failed // 0 | tonumber? // 0)] | add // 0')
+  errors=$(printf '%s' "$normalized_results" | jq '[.[] | (.errors // 0 | tonumber? // 0)] | add // 0')
+  detailed_logs=$(printf '%s' "$normalized_results" | jq -c '[.[] | (.detailed_logs // [])[]?]')
+  screenshots_and_video=$(printf '%s' "$normalized_results" | jq -c '[.[] | (.screenshots_and_video // [])[]?]')
+  start_time=$(printf '%s' "$normalized_results" | jq -r '[.[] | .start_time // empty] | min // ""')
+  end_time=$(printf '%s' "$normalized_results" | jq -r '[.[] | .end_time // empty] | max // ""')
+  result_urls=$(printf '%s' "$hashes_json" | jq -c 'map("https://app.endtest.io/results?hash=" + .)')
+
+  if [[ "$execution_count" -eq 1 ]]; then
+    results=$(printf '%s' "$result_urls" | jq -r '.[0]')
+  else
+    results="$result_urls"
+  fi
+
+  echo "Endtest executions: $execution_count"
+  echo "Test Suite Name(s): $test_suite_name"
+  echo "Configuration(s): $configuration"
+  echo "Test Cases: $test_cases"
+  echo "Passed: $passed"
+  echo "Failed: $failed"
+  echo "Errors: $errors"
+  echo "Start Time: $start_time"
+  echo "End Time: $end_time"
+  echo "Hash(es): $hash"
+  echo "Results: $results"
+
+  write_output "test_suite_name" "$test_suite_name"
+  write_output "configuration" "$configuration"
+  write_output "test_cases" "$test_cases"
+  write_output "passed" "$passed"
+  write_output "failed" "$failed"
+  write_output "errors" "$errors"
+  write_output "start_time" "$start_time"
+  write_output "end_time" "$end_time"
+  write_output "detailed_logs" "$detailed_logs"
+  write_output "screenshots_and_video" "$screenshots_and_video"
+  write_output "hash" "$hash"
+  write_output "results" "$results"
+  write_output "execution_count" "$execution_count"
+  write_output "hashes" "$hashes_json"
+  write_output "result_urls" "$result_urls"
+  write_output "test_executions" "$normalized_results"
+  exit 0
 done
-exit
+
+if [[ -n "$last_status" ]]; then
+  echo "Timed out while waiting for Endtest results. Last status: $last_status" >&2
+else
+  echo "Timed out while waiting for Endtest results." >&2
+fi
+exit 1


### PR DESCRIPTION
## Summary

Adds support for triggering and processing multiple Endtest test executions from a single API request.

This allows API requests that use a label, such as `label=Critical`, to return multiple comma-separated execution hashes and fetch all corresponding results in one `getResults` request.

## Changes

* Supports both single and comma-separated execution hashes
* Supports result responses containing either one object or an array of objects
* Waits until results are available for all returned execution hashes
* Adds support for both `json` and `json-light` through the `results_format` input
* Aggregates test case, passed, failed, and error counts
* Uses the earliest start time and latest end time across all executions
* Combines detailed logs and media URLs across executions
* Adds the following outputs:

  * `execution_count`
  * `hashes`
  * `result_urls`
  * `test_executions`
* Replaces the deprecated `::set-output` syntax with `$GITHUB_OUTPUT`
* Returns an error when polling times out or the Endtest API returns an invalid response
* Updates the README with examples for triggering multiple suites with a label

## Backward compatibility

Single-suite API requests continue to work.

For a single execution, existing outputs such as `test_suite_name`, `configuration`, and `results` remain scalar values.

For multiple executions, those outputs contain JSON arrays, while numeric outputs contain aggregated totals.

## Validation

* `git diff --check`
* `bash -n test.sh`
* Tested with mocked single-execution results
* Tested with mocked multiple-execution results
* Tested with temporary running and partial result responses
* Tested with both `json` and `json-light`
